### PR TITLE
removed ERD from db / manual project migration

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -48,6 +48,6 @@ end
 group :development do
   # Speed up commands on slow machines / big apps [https://github.com/rails/spring]
   # gem "spring"
-  gem 'erd', '~> 0.8.1'
+  # gem 'erd', '~> 0.8.1', require: true
 end
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -83,9 +83,6 @@ GEM
       irb (>= 1.3.6)
       reline (>= 0.2.7)
     digest (3.1.0)
-    erd (0.8.1)
-      nokogiri
-      ruby-graphviz
     erubi (1.10.0)
     globalid (1.0.0)
       activesupport (>= 5.0)
@@ -163,9 +160,6 @@ GEM
     rake (13.0.6)
     reline (0.3.1)
       io-console (~> 0.5)
-    rexml (3.2.5)
-    ruby-graphviz (1.2.5)
-      rexml
     strscan (3.0.1)
     thor (1.2.1)
     timeout (0.2.0)
@@ -184,7 +178,6 @@ DEPENDENCIES
   bcrypt (~> 3.1.7)
   bootsnap
   debug
-  erd (~> 0.8.1)
   jwt
   pg (~> 1.1)
   puma (~> 5.0)

--- a/README.md
+++ b/README.md
@@ -376,15 +376,3 @@ I've opted for method two in my implementation.
 ## Part II -- Coming soon
 
 In part 2, we will create and make associations for a user authentication
-
-```
-
-```
-
-```
-
-```
-
-```
-
-```

--- a/db/migrate/20220406202919_create_projects.rb
+++ b/db/migrate/20220406202919_create_projects.rb
@@ -1,0 +1,13 @@
+class CreateProjects < ActiveRecord::Migration[7.0]
+
+  def change
+    create_table :projects do |t|
+      t.string "project_name"
+      t.string "project_type"
+      t.string "project_tags"
+      t.string "description"
+    end
+  end
+end
+
+

--- a/lib/tasks/auto_generate_diagram.rake
+++ b/lib/tasks/auto_generate_diagram.rake
@@ -1,6 +1,0 @@
-# NOTE: only doing this in development as some production environments (Heroku)
-# NOTE: are sensitive to local FS writes, and besides -- it's just not proper
-# NOTE: to have a dev-mode tool do its thing in production.
-if Rails.env.development?
-  RailsERD.load_tasks
-end


### PR DESCRIPTION
Remove Rails ERD Gem and auto-generate file from lib that was causing migrations to fail

Manually created Projects migration as seems it was deleted and heroko migration is looking for it 